### PR TITLE
fix: restore GROUP_INCLUDE_USERNAME logic avoiding Listen Mode conflict

### DIFF
--- a/src/telegram/handler/chat.ts
+++ b/src/telegram/handler/chat.ts
@@ -159,9 +159,18 @@ export class ChatHandler implements MessageHandler<WorkerContext> {
         const { type, id } = context.MIDDLE_CONTEXT.messageInfo;
         let messageText = message.text || message.caption || '';
 
-        // Note: We don't add user prefix to current message to avoid AI repeating it
-        // User identification is only shown in cached group messages history
-        // This makes AI responses cleaner while maintaining context awareness
+        // Get user identifier for group chats
+        // Skip if GROUP_MESSAGE_LISTEN_MODE is active (user info already in cache context)
+        let userPrefix = '';
+        if (ENV.GROUP_INCLUDE_USERNAME && !ENV.GROUP_MESSAGE_LISTEN_MODE && isTelegramChatTypeGroup(message.chat.type)) {
+            const userIdentifier = getUserIdentifier(message.from);
+            if (userIdentifier) {
+                userPrefix = `${userIdentifier}: `;
+                if (messageText) {
+                    messageText = userPrefix + messageText;
+                }
+            }
+        }
 
         const params: LLMChatRequestParams = {
             role: 'user',
@@ -190,6 +199,11 @@ export class ChatHandler implements MessageHandler<WorkerContext> {
                 defaultText = context.USER_CONFIG.AUDIO_PROMPT;
             } else {
                 defaultText = `Please explain the ${type}`;
+            }
+
+            // Add user identifier prefix if in group chat
+            if (userPrefix) {
+                defaultText = userPrefix + defaultText;
             }
 
             params.content.push({


### PR DESCRIPTION
**Description:**
In commit c9295cf72a378ed62f2ee809f31a0e2090a855b8, the support for `GROUP_INCLUDE_USERNAME` was removed to prevent duplicate username prefixes when `GROUP_MESSAGE_LISTEN_MODE` was enabled.

However, this removed the feature for users who want prefixes but are **not** using Listen Mode.

**Changes:**
This PR restores the logic to prepend the `userPrefix` in group chats but adds a safeguard:
```typescript
if (ENV.GROUP_INCLUDE_USERNAME && !ENV.GROUP_MESSAGE_LISTEN_MODE && ...)
```
This ensures that:
1. `GROUP_INCLUDE_USERNAME` works again for standard group chats.
2. It is automatically skipped if `GROUP_MESSAGE_LISTEN_MODE` is active, avoiding the duplication issue addressed in the previous removal.